### PR TITLE
Qt 5.11 beta: passworddialog.cpp: include QIcon explicitely

### DIFF
--- a/passworddialog.cpp
+++ b/passworddialog.cpp
@@ -27,6 +27,7 @@
 
 #include "passworddialog.h"
 #include "ui_passworddialog.h"
+#include <QIcon>
 
 PasswordDialog::PasswordDialog(QStringList argv
         , QWidget * parent/* = 0*/


### PR DESCRIPTION
5.11 Qt headers do not indirectly include QIcon resulting in compile
time errors like:
| passworddialog.cpp:44:33: error: incomplete type 'QIcon' used in nested name specifier

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>