### PR TITLE
sudo: Prevent malicious attempts for command injection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(lxqt-sudo
     Qt5::Widgets
     util
     lxqt
+    -pthread
 )
 
 target_compile_definitions(lxqt-sudo

--- a/sudo.cpp
+++ b/sudo.cpp
@@ -233,6 +233,13 @@ void Sudo::child()
         command = "unset LC_ALL; ";
     } else
     {
+        // Note: we need to check if someone is not trying to inject commands
+        // for privileged execution via the LC_ALL
+        if (nullptr != strchr(env_lc_all, '\''))
+        {
+            QTextStream{stderr, QIODevice::WriteOnly} << tr("%1: Detected attempt to inject privileged command via LC_ALL env(%2). Exitting!\n").arg(app_master).arg(env_lc_all);
+            exit(1);
+        }
         command = "LC_ALL='";
         command += env_lc_all;
         command += "' ";


### PR DESCRIPTION
With the #46 we created a possibility for injection of commands via the LC_ALL env. variable (I didn't think of such malicious usage at that time).
Example of such malicious script is as easy as (**do not try it w/o the `echo`**):
`LC_ALL=\'\ 'echo rm -f /'\' ./lxqt-sudo ls`
... command to execute presented to the user will be `ls`, but...

We prevent this by simply checking if the LC_ALL contains `'` ...