### PR TITLE
UI enhancements

### DIFF
--- a/passworddialog.cpp
+++ b/passworddialog.cpp
@@ -28,8 +28,11 @@
 #include "passworddialog.h"
 #include "ui_passworddialog.h"
 #include <QIcon>
+#include <QClipboard>
+#include <QToolButton>
 
 PasswordDialog::PasswordDialog(const QString & cmd
+        , const QString & backendName
         , QWidget * parent/* = 0*/
         , Qt::WindowFlags f/* = 0*/)
     : QDialog(parent, f)
@@ -38,7 +41,12 @@ PasswordDialog::PasswordDialog(const QString & cmd
     ui->setupUi(this);
 
     ui->commandL->setText(cmd);
-    ui->descriptionL->setText(tr("<b>%1</b> needs administrative privileges.<br>Please enter your password.").arg(cmd));
+
+    connect(ui->commandCopyBtn, &QToolButton::clicked, [cmd]() {
+        QApplication::clipboard()->setText (cmd);
+    });
+
+    ui->backendL->setText(backendName);
     ui->iconL->setPixmap(QIcon::fromTheme("dialog-password").pixmap(64, 64));
     setWindowIcon(QIcon::fromTheme("security-high"));
 }
@@ -50,6 +58,7 @@ PasswordDialog::~PasswordDialog()
 void PasswordDialog::showEvent(QShowEvent * event)
 {
     ui->errorL->setText(tr("Attempt #%1").arg(++mAttempt));
+    ui->passwordLE->setFocus();
     return QDialog::showEvent(event);
 }
 

--- a/passworddialog.h
+++ b/passworddialog.h
@@ -40,12 +40,15 @@ class PasswordDialog : public QDialog
 
 public:
     PasswordDialog(const QString & cmd
+            , const QString & backendName
             , QWidget * parent = 0
             , Qt::WindowFlags f = 0);
     ~PasswordDialog();
 
-    virtual void showEvent(QShowEvent * event) override;
     QString password() const;
+
+protected:
+    virtual void showEvent(QShowEvent * event) override;
 
 private:
     QScopedPointer<Ui::PasswordDialog> ui;

--- a/passworddialog.ui
+++ b/passworddialog.ui
@@ -2,42 +2,58 @@
 <ui version="4.0">
  <class>PasswordDialog</class>
  <widget class="QDialog" name="PasswordDialog">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>200</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>LXQt sudo</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0" rowspan="2" alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-      <widget class="QLabel" name="iconL">
-       <property name="text">
-        <string/>
+     <item row="2" column="1">
+      <layout class="QHBoxLayout" name="commandLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="1" alignment="Qt::AlignVCenter">
-      <widget class="QLabel" name="descriptionL">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
+       <item>
+        <widget class="QLabel" name="commandL">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::Panel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Sunken</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="commandCopyBtn">
+         <property name="toolTip">
+          <string>Copy command to clipboard</string>
+         </property>
+         <property name="text">
+          <string>&amp;Copy</string>
+         </property>
+         <property name="icon">
+          <iconset theme="edit-copy">
+           <normaloff>.</normaloff>.</iconset>
+         </property>
+         <property name="toolButtonStyle">
+          <enum>Qt::ToolButtonIconOnly</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item row="1" column="1">
       <widget class="QLabel" name="errorL">
@@ -47,46 +63,75 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+      </widget>
+     </item>
+     <item row="0" column="1" alignment="Qt::AlignVCenter">
+      <widget class="QLabel" name="descriptionL">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>230</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string/>
+        <string>The requested action needs administrative privileges.&lt;br&gt;Please enter your password.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="commandL">
+     <item row="0" column="0">
+      <widget class="QLabel" name="iconL">
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="backendL">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string/>
+       <property name="toolTip">
+        <string>LXQt sudo backend</string>
+       </property>
+       <property name="whatsThis">
+        <string>A program LXQt sudo calls in background to elevate priveledges.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="descCommandL">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <property name="text">
         <string>Command:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="3" column="0" rowspan="2">
       <widget class="QLabel" name="descPasswordL">
        <property name="text">
         <string>Password:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1" rowspan="2">
       <widget class="QLineEdit" name="passwordLE">
+       <property name="toolTip">
+        <string>Enter password</string>
+       </property>
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>
        </property>
@@ -103,6 +148,9 @@
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -113,6 +161,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>passwordLE</tabstop>
+  <tabstop>buttonBox</tabstop>
+  <tabstop>commandCopyBtn</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/sudo.h
+++ b/sudo.h
@@ -50,6 +50,20 @@ public:
     Sudo();
     ~Sudo();
     int main();
+
+    /// A name of the backend for the purpose of the display to the user
+    QString backendName() {
+        return backendName(mBackend);
+    }
+    /// A static version of previous one.
+    /// @returns a backend name for the given \p backEnd.
+    static QString backendName (backend_t backEnd);
+    ///
+    /// @returns a squashed and quoted string of arguments suitable to passsed to shell
+    /// @arg userFriendly  -  if true, performes a smarter quoting (e.g. no quoting for
+    ///                       string with no special characters)
+    QString squashedArgs (bool userFriendly=0) const;
+
 private:
     //parent methods
     int parent();
@@ -62,7 +76,6 @@ private:
     QScopedPointer<PasswordDialog> mDlg;
     QStringList mArgs;
     backend_t mBackend;
-    QString mSquashedArgs;
 
     int mChildPid;
     int mPwdFd;


### PR DESCRIPTION
Several UI enhancement of PasswordDialog:
- Avoid printing command twice
- Add a button to copy command
- Alter command label style
- Add a label to display current authorization backend
- Avoid displaying extraneous quoting (keep full quoting for command line)

The UI looks like this now:
![scr8](https://user-images.githubusercontent.com/1060057/50553771-68052d00-0cbe-11e9-96f8-a97e68ae8df5.png)

Also there are some code cleanups:
- Use `toLocal8Bit()` or `toLatin1()` then converting QStrings to char*
  rather than `toStdString()`. The last one implicitly uses `toUtf8()`
  which upsets some rare systems with non-utf8 locales.
- Small reorganization of code in sudo.cpp.

PS: I'm open for discussion if you don't like some of those changes.