### PR TITLE
Allow building on *BSD systems

### DIFF
--- a/sudo.cpp
+++ b/sudo.cpp
@@ -39,7 +39,7 @@
 #include <QProcessEnvironment>
 #include <QTimer>
 #include <QRegularExpression>
-#if defined(__Linux__)
+#if defined(__Q_OS_LINUX__)
 #include <pty.h>
 #else
 #include <errno.h>

--- a/sudo.cpp
+++ b/sudo.cpp
@@ -39,7 +39,13 @@
 #include <QProcessEnvironment>
 #include <QTimer>
 #include <QRegularExpression>
+#if defined(__Linux__)
 #include <pty.h>
+#else
+#include <errno.h>
+#include <termios.h>
+#include <util.h>
+#endif
 #include <unistd.h>
 #include <memory>
 #include <csignal>

--- a/sudo.cpp
+++ b/sudo.cpp
@@ -39,7 +39,7 @@
 #include <QProcessEnvironment>
 #include <QTimer>
 #include <QRegularExpression>
-#if defined(__Q_OS_LINUX__)
+#if defined(Q_OS_LINUX)
 #include <pty.h>
 #else
 #include <errno.h>


### PR DESCRIPTION
I'm currently packaging LXQt for NetBSD and there are a few patches needed.
Please allow building on *BSD systems. Thanks!